### PR TITLE
Enable OpenH264 and AVC444 support for KRDP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,6 +91,7 @@ RUN set -eux; \
     -DWITH_KRB5=ON \
     -DWITH_MANPAGES=OFF \
     -DWITH_OPENH264=ON \
+    -DWITH_OPENH264_LOADING=ON \
     -DWITH_OPENSSL=ON \
     -DWITH_OPUS=ON \
     -DWITH_OSS=OFF \
@@ -138,13 +139,15 @@ RUN apk add --no-cache                \
         libwebp-dev                   \
         libwebsockets-dev             \
         make                          \
+        openh264-dev                  \
         openssl-dev                   \
         pango-dev                     \
         pkgconf                       \
         pulseaudio-dev                \
         tar                           \
         util-linux-dev                \
-        wget
+        wget                          \
+        x264-dev
 
 RUN set -eux; \
   rm -rf "${BUILD_DIR}"; \
@@ -158,10 +161,10 @@ RUN set -eux; \
     mv "/tmp/guacamole-server-${VERSION}" "${BUILD_DIR}"; \
     cd "${BUILD_DIR}"; \
     sed -i \
-      's/freerdp_settings_set_bool(rdp_settings, FreeRDP_SupportGraphicsPipeline, TRUE);/freerdp_settings_set_bool(rdp_settings, FreeRDP_SupportGraphicsPipeline, TRUE);\n        freerdp_settings_set_bool(rdp_settings, FreeRDP_GfxH264, TRUE);/' \
+      's/freerdp_settings_set_bool(rdp_settings, FreeRDP_SupportGraphicsPipeline, TRUE);/freerdp_settings_set_bool(rdp_settings, FreeRDP_SupportGraphicsPipeline, TRUE);\n        freerdp_settings_set_bool(rdp_settings, FreeRDP_GfxH264, TRUE);\n        freerdp_settings_set_bool(rdp_settings, FreeRDP_GfxAVC444, TRUE);/' \
       "${BUILD_DIR}/src/protocols/rdp/settings.c"; \
     sed -i \
-      's/rdp_settings->SupportGraphicsPipeline = TRUE;/rdp_settings->SupportGraphicsPipeline = TRUE;\n        rdp_settings->GfxH264 = TRUE;/' \
+      's/rdp_settings->SupportGraphicsPipeline = TRUE;/rdp_settings->SupportGraphicsPipeline = TRUE;\n        rdp_settings->GfxH264 = TRUE;\n        rdp_settings->GfxAVC444 = TRUE;/' \
       "${BUILD_DIR}/src/protocols/rdp/settings.c"; \
     ./configure \
       --prefix="${PREFIX_DIR}" \


### PR DESCRIPTION
Recent additn of support for KRDP was not enough, as some dependencies were missing during build.

I've added required libraries and modified sed to properly use new changes


> ldd {LIBRARY} | grep -E "avcodec|swscale|avutil|x264|openh264"
```Bash
[/opt/guacamole/sbin/guacd]

[/opt/guacamole/lib/libguac-client-rdp.so]
        libswscale.so.7 => /usr/lib/libswscale.so.7 (0x7f282e656000)
        libavutil.so.58 => /usr/lib/libavutil.so.58 (0x7f282d53f000)
        libavcodec.so.60 => /usr/lib/libavcodec.so.60 (0x7f282bf5b000)
        libopenh264.so.8 => /usr/lib/libopenh264.so.8 (0x7f282bdaf000)
        libx264.so.164 => /usr/lib/libx264.so.164 (0x7f28295f2000)

[/opt/guacamole/lib/libfreerdp3.so.3]
        libswscale.so.7 => /usr/lib/libswscale.so.7 (0x7fbd43e40000)
        libavutil.so.58 => /usr/lib/libavutil.so.58 (0x7fbd42d29000)
        libavcodec.so.60 => /usr/lib/libavcodec.so.60 (0x7fbd412f7000)
        libopenh264.so.8 => /usr/lib/libopenh264.so.8 (0x7fbd4114b000)
        libx264.so.164 => /usr/lib/libx264.so.164 (0x7fbd3ee5a000)

[/opt/guacamole/lib/libfreerdp-client3.so]
        libswscale.so.7 => /usr/lib/libswscale.so.7 (0x7fca32775000)
        libavutil.so.58 => /usr/lib/libavutil.so.58 (0x7fca3165e000)
        libavcodec.so.60 => /usr/lib/libavcodec.so.60 (0x7fca2fc2c000)
        libopenh264.so.8 => /usr/lib/libopenh264.so.8 (0x7fca2fa80000)
        libx264.so.164 => /usr/lib/libx264.so.164 (0x7fca2d563000)
```